### PR TITLE
Écriture de la vue pour un interne

### DIFF
--- a/csar/choix/models.py
+++ b/csar/choix/models.py
@@ -11,7 +11,7 @@ class StageManager(models.Manager):
     - documentation Django : https://docs.djangoproject.com/en/4.0/topics/db/managers/
     """
 
-    def est_disponible(self):
+    def disponibles(self):
         """
         Retourne un QuerySet permettant de filtrer sur la disponibilité du stage.
         Ainsi, Stages.objects.est_disponible() renverra la liste de tous les stages

--- a/csar/choix/models.py
+++ b/csar/choix/models.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+import uuid
 
 
 class Stage(models.Model):
@@ -61,6 +62,8 @@ class Interne(models.Model):
     Attributs :
         - nom, prenom, mail, et telephone : sont stockés sous forme de strings
         - stage : le stage choisi par l'interne
+        - uuid: un identifiant unique (UUID = "universally unique identifier") qui permettra
+            d'accéder à la page de l'interne sans mettre en clair dans l'URL la clé primaire
     """
     nom = models.CharField(max_length=200)
     prenom = models.CharField(max_length=200)
@@ -71,6 +74,7 @@ class Interne(models.Model):
         blank=True,
         through="Choix",
     )
+    uuid = models.UUIDField(default=uuid.uuid4)
 
     def __str__(self):
         return self.prenom + ' ' + self.nom

--- a/csar/choix/templates/choix/index.html
+++ b/csar/choix/templates/choix/index.html
@@ -4,6 +4,10 @@
 
 {% block content %}
 
+{% if error_message %}
+    <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+{% endif %}
+
 <div class="card">
   <div class="card-header">
     <h5 class="card-title">Stages disponibles</h5>

--- a/csar/choix/templates/choix/interne.html
+++ b/csar/choix/templates/choix/interne.html
@@ -1,1 +1,30 @@
-Salut à toi, {{ interne.prenom }} {{ interne.nom }} !
+{% extends 'choix/base.html' %}
+
+{% block title %}Choix des stages DESAR Grenoble{% endblock title %}
+
+{% block content %}
+
+{% if error_message %}
+    <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+{% endif %}
+
+<div class="card">
+  <div class="card-header">
+    <h5 class="card-title">Salut à toi, {{ interne.prenom }} {{ interne.nom }} !
+        Voici la liste des stages disponibles pour toi :</h5>
+  </div>
+  <ul class="list-group list-group-flush">
+    {% for stage in liste_stages %}
+        <li class="list-group-item">
+            {{ stage.intitule }}
+
+            <small class="d-block text-muted"> Durée : {{ stage.duree_en_mois }} mois </small>
+            <small class="d-block text-muted">
+                Places disponibles : {{ stage.nombre_postes_disponibles }} / {{ stage.nombre_postes_ouverts }}
+            </small>
+        </li>
+    {% endfor %}
+  </ul>
+</div>
+
+{% endblock content %}

--- a/csar/choix/templates/choix/interne.html
+++ b/csar/choix/templates/choix/interne.html
@@ -1,0 +1,1 @@
+Salut à toi, {{ interne.prenom }} {{ interne.nom }} !

--- a/csar/choix/templates/choix/interne.html
+++ b/csar/choix/templates/choix/interne.html
@@ -1,6 +1,6 @@
 {% extends 'choix/base.html' %}
 
-{% block title %}Choix des stages DESAR Grenoble{% endblock title %}
+{% block title %}{{ interne.prenom }} {{ interne.nom }} | Choix des stages DESAR Grenoble{% endblock title %}
 
 {% block content %}
 

--- a/csar/choix/tests.py
+++ b/csar/choix/tests.py
@@ -21,6 +21,21 @@ class StageModelsTests(TestCase):
         Choix.objects.create(interne=interne2, stage=stage)
         self.assertEqual(stage.nombre_postes_disponibles(), 1)
 
+    def test_est_disponible(self):
+        # on crée un stage avec un seul poste disponible
+        stage = Stage.objects.create(intitule="stage", nombre_postes_ouverts=1)
+        # on vérifie qu'il est bien disponible
+        self.assertTrue(stage.est_disponible())
+        # on vérifie que le nombre de stage disponibles est bien égal à 1
+        self.assertEqual(Stage.objects.disponibles().count(), 1)
+        # on crée un interne qui va choisir le stage
+        interne = Interne.objects.create(prenom="Interne", nom="au pif")
+        stage.interne_set.add(interne)
+        # le stage n'est alors plus disponible
+        self.assertFalse(stage.est_disponible())
+        # le nombre de stages disponibles est alors égal à 0
+        self.assertEqual(Stage.objects.disponibles().count(), 0)
+
 
 class ChoixModelsTests(TestCase):
     def test_relation_plusieurs_a_plusieurs(self):

--- a/csar/choix/urls.py
+++ b/csar/choix/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('<str:interne_uuid>/', views.choix_interne, name='choix_interne')
 ]

--- a/csar/choix/views.py
+++ b/csar/choix/views.py
@@ -25,7 +25,7 @@ def choix_interne(request, interne_uuid):
         return index(request, error_message="Erreur: plusieurs internes ont le même identifiant unique")
 
     # pour l'affichage de l'interne
-    liste_stages = Stage.objects.est_disponible().order_by("intitule")
+    liste_stages = Stage.objects.disponibles().order_by("intitule")
     context = {'interne': interne,
                'liste_stages': liste_stages}
     return render(request, 'choix/interne.html', context)

--- a/csar/choix/views.py
+++ b/csar/choix/views.py
@@ -1,9 +1,21 @@
-from django.shortcuts import render
+from django.core.exceptions import MultipleObjectsReturned
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, render
 
-from .models import Stage
+from .models import Interne, Stage
 
 
-def index(request):
+def index(request, error_message=None):
     liste_stages = Stage.objects.all().order_by("intitule")
     context = {'liste_stages': liste_stages}
+    if error_message is not None:
+        context['error_message'] = error_message
     return render(request, 'choix/index.html', context=context)
+
+
+def choix_interne(request, interne_uuid):
+    try:
+        interne = get_object_or_404(Interne, uuid=interne_uuid)
+    except MultipleObjectsReturned:  # si plusieurs internes ont le même uuid
+        return index(request, error_message="Erreur: plusieurs internes ont le même identifiant unique")
+    return render(request, 'choix/interne.html', {'interne': interne})

--- a/csar/choix/views.py
+++ b/csar/choix/views.py
@@ -14,8 +14,18 @@ def index(request, error_message=None):
 
 
 def choix_interne(request, interne_uuid):
+    """
+    Page associée à un interne, qui peut se retrouver via son uuid.
+    On y affiche seulement les stages disponibles, pour qu'il fasse son choix.
+    """
     try:
         interne = get_object_or_404(Interne, uuid=interne_uuid)
+
     except MultipleObjectsReturned:  # si plusieurs internes ont le même uuid
         return index(request, error_message="Erreur: plusieurs internes ont le même identifiant unique")
-    return render(request, 'choix/interne.html', {'interne': interne})
+
+    # pour l'affichage de l'interne
+    liste_stages = Stage.objects.est_disponible().order_by("intitule")
+    context = {'interne': interne,
+               'liste_stages': liste_stages}
+    return render(request, 'choix/interne.html', context)


### PR DESCRIPTION
L'idée est qu'un interne recevra une url, sous la forme [http://adresse.com/choix/uuid](http://adresse.com/choix/uuid), où `uuid` est un identifiant unique (par exemple `f6ff13fa-9e0d-4b32-b26d-bae15ad65623`). Ceci permet d'éviter qu'un autre interne mal intentionné devine le schéma des clés primaires et rentre dans la page d'un interne. C'est donc une sécurité qui n'a pas besoin de système de login (ce qui à mon sens facilite l'acceptabilité de l'outil : les internes recevront juste un lien URL, auront juste à cliquer dessus puis à choisir).